### PR TITLE
Add -TimeoutSec option to Invoke-WebRequest calls

### DIFF
--- a/bin/support-diagnostics.bat
+++ b/bin/support-diagnostics.bat
@@ -14,10 +14,11 @@ IF /I "%~1"=="-i" SET i="%~2"
 IF /I "%~1"=="-a" SET a="%~2"
 IF /I "%~1"=="-c" SET c="%~2"
 IF /I "%~1"=="-p" SET p="%~2"
+IF /I "%~1"=="-t" SET t="%~2"
 SHIFT & GOTO loop
 :cont
 
-SET Command="& '%PowerShellScript%' -H '%H%' -o '%o%' -n '%n%' -r '%r%' -i '%i%' -a '%a%' -c '%c%' -p '%p%'"
+SET Command="& '%PowerShellScript%' -H '%H%' -o '%o%' -n '%n%' -r '%r%' -i '%i%' -a '%a%' -c '%c%' -p '%p%' -t '%t%'"
 IF "%nc%" == "1" (
 	SET Command=%Command% -nc
 )


### PR DESCRIPTION
This commit adds a new option to the Windows script, `-t` allowing to
set a timeout (in seconds) for the REST API requests to Elasticsearch in
case these take a long time or hang.  This is done through the
`-TimeoutSec` option to the `Invoke-WebRequest` cmdlet.