### PR TITLE
Enabled delayed expansion and fix use of DIAG_JAVA_OPTIONS

### DIFF
--- a/scripts/diagnostics.bat
+++ b/scripts/diagnostics.bat
@@ -1,19 +1,19 @@
 @echo off
-setlocal
+setlocal enabledelayedexpansion
 
 set JAVA_EXEC=java
-if not defined JAVA_HOME ( 
+if not defined JAVA_HOME (
   set JAVA_EXEC=java
   echo No Java Home was found. Using current path. If execution fails please install Java and make sure it is in the search path or exposed via the JAVA_HOME environment variable.
 ) else (
-  echo JAVA_HOME found, using %JAVA_HOME%
-  set JAVA_EXEC=%JAVA_HOME%\bin\java
+  echo JAVA_HOME found, using !JAVA_HOME!
+  set JAVA_EXEC=!JAVA_HOME!\bin\java
 )
 
-if not defined DIAG_JAVA_OPTIONS ( 
-  set DIAG_JAVA_OPTIONS=-Xmx512m 
+if not defined DIAG_JAVA_OPTIONS (
+  set DIAG_JAVA_OPTIONS=-Xmx512m
 )
 
-"%JAVA_EXEC%" %DIAG JAVA_OPTIONS% -cp .\;.\lib\* com.elastic.support.diagnostics.DiagnosticApp %*
+"%JAVA_EXEC%" %DIAG_JAVA_OPTIONS% -cp .\;.\lib\* com.elastic.support.diagnostics.DiagnosticApp %*
 
 endlocal


### PR DESCRIPTION
For properly dealing with parenthesis in JAVA_HOME, for instance `C:\Program Files (x86)\Java\jdk1.8.0_74`.

See https://blogs.msdn.microsoft.com/oldnewthing/20060823-00/?p=29993 for details.

Also looks like `DIAG_JAVA_OPTIONS` was used improperly (`DIAG JAVA_OPTIONS` instead).  Note the space rather than underscore.