### PR TITLE
Add jstack to diagnostics dump

### DIFF
--- a/src/main/java/com/elastic/support/diagnostics/commands/SystemCallsCmd.java
+++ b/src/main/java/com/elastic/support/diagnostics/commands/SystemCallsCmd.java
@@ -19,18 +19,18 @@ public class SystemCallsCmd extends AbstractDiagnosticCmd {
       pb.redirectErrorStream(true);
 
       Iterator<Map.Entry<String, String>> iter = osCmds.entrySet().iterator();
-      List cmds = new ArrayList();
+      final List<String> cmds = new ArrayList<>();
 
       while (iter.hasNext()) {
          Map.Entry<String, String> entry =  iter.next();
          String cmdLabel = entry.getKey();
-         String cmdText = entry.getValue();
+         final String cmdText;
+         if (entry.getValue().contains("PID")) {
+            cmdText = entry.getValue().replace("PID", context.getPid());
+         } else {
+            cmdText = entry.getValue();
+         }
          try {
-            // One off hack for process limits
-            if (cmdLabel.equals("proc-limit")) {
-               cmdText = "cat /proc/" + context.getPid() + "/limits";
-            }
-
             StringTokenizer st = new StringTokenizer(cmdText, " ");
             while (st.hasMoreTokens()) {
                cmds.add(st.nextToken());

--- a/src/main/resources/diags.yml
+++ b/src/main/resources/diags.yml
@@ -170,6 +170,7 @@ linuxOS:
   proc-limit: "cat /proc/PID/limits"
   cpu: "cat /proc/cpuinfo"
   jps: "jps -l -m -v"
+  jstack: "jstack PID"
   iostat: "iostat -c -d -x -t -m"
   sar: "sar -A"
   sysctl: "sysctl -a"
@@ -181,9 +182,11 @@ macOS:
   process-list: "ps -ef"
   ulimit: "ulimit -a"
   jps: "jps -l -m -v"
+  jstack: "jstack PID"
 
 winOS:
   process-list: "tasklist /v"
   netstat: "netstat -ano"
   jps: "jps -l -m -v"
+  jstack: "jstack PID"
   cpu: "wmic CPU"


### PR DESCRIPTION
Having the output from jstack in diagnostics dumps would be incredibly helpful so this commit adds that.