### PR TITLE
Throw helpful error message on unsupported major

### DIFF
--- a/src/main/java/com/elastic/support/diagnostics/commands/RunClusterQueriesCmd.java
+++ b/src/main/java/com/elastic/support/diagnostics/commands/RunClusterQueriesCmd.java
@@ -9,8 +9,11 @@ public class RunClusterQueriesCmd extends AbstractQueryCmd {
 
    public boolean execute(DiagnosticContext context) {
 
-      String majorVersion = context.getVersion().substring(0, 1);
+      String majorVersion = context.getVersion().split("\\.")[0];
       Map<String, String> statements = (Map<String, String>) context.getConfig().get("restQueries-" + majorVersion);
+      if (statements == null) {
+         throw new IllegalArgumentException("major version [" + majorVersion + "] is not supported by this diagnostics tool");
+      }
       Set<Map.Entry<String, String>> entries = statements.entrySet();
 
       logger.debug("Generating full diagnostic.");


### PR DESCRIPTION
Today if the diagnostics tool is run against a major version that it does not support it throws a null pointer exception and does not really reveal what the problem is. This commit traps this situation and provides a helpful error message to the user.

Additionally, the logic for parsing the major version is broken as it will fail when the major version has two digits. This commit fixes this situation too.