### PR TITLE
Dump network address cache security properties

### DIFF
--- a/src/main/java/com/elastic/support/diagnostics/commands/SecurityPropertiesCmd.java
+++ b/src/main/java/com/elastic/support/diagnostics/commands/SecurityPropertiesCmd.java
@@ -1,0 +1,62 @@
+package com.elastic.support.diagnostics.commands;
+
+import com.elastic.support.diagnostics.chain.DiagnosticContext;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.Security;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+public final class SecurityPropertiesCmd extends AbstractDiagnosticCmd {
+
+    @Override
+    public boolean execute(final DiagnosticContext context) {
+        final Path path = Paths.get(context.getOutputDir(), "diagnostics", "security-properties.txt");
+        try (
+                OutputStream outpuStream = new FileOutputStream(path.toFile());
+                OutputStreamWriter outputStreamWriter = new OutputStreamWriter(outpuStream);
+                BufferedWriter writer = new BufferedWriter(outputStreamWriter)) {
+            try {
+                final List<String> securityProperties = readSecurityProperites();
+                for (final String securityProperty : securityProperties) {
+                    writer.write(securityProperty);
+                }
+            } catch (final IOException e) {
+                try (PrintWriter printWriter = new PrintWriter(writer)) {
+                    e.printStackTrace(printWriter);
+                    return false;
+                }
+            }
+        } catch (final IOException e) {
+            logger.error("failed opening " + path.toString(), e);
+            return false;
+        }
+        return true;
+    }
+
+    private List<String> readSecurityProperites() throws IOException {
+        try (InputStream inputStream = Thread.currentThread().getContextClassLoader().getResourceAsStream("security-properties.txt");
+             InputStreamReader inputStreamReader = new InputStreamReader(inputStream);
+             BufferedReader reader = new BufferedReader(inputStreamReader)) {
+            final List<String> result = new ArrayList<>();
+            while (true) {
+                final String line = reader.readLine();
+                if (line == null) break;
+                result.add(String.format(Locale.ROOT, "%s=%s\n", line, Security.getProperty(line)));
+            }
+            return result;
+        }
+    }
+
+}

--- a/src/main/resources/chains.yml
+++ b/src/main/resources/chains.yml
@@ -10,6 +10,7 @@ standard:
 #  - com.elastic.support.diagnostics.commands.ThreadDumpCmd
   - com.elastic.support.diagnostics.commands.ScrubPasswordsCmd
   - com.elastic.support.diagnostics.commands.ScrubLogsCmd
+  - com.elastic.support.diagnostics.commands.SecurityPropertiesCmd
   - com.elastic.support.diagnostics.commands.GenerateManifestCmd
   - com.elastic.support.diagnostics.commands.ArchiveResultsCmd
   - com.elastic.support.diagnostics.commands.CleanupCmd

--- a/src/main/resources/security-properties.txt
+++ b/src/main/resources/security-properties.txt
@@ -1,0 +1,2 @@
+networkaddress.cache.ttl
+networkaddress.cache.negative.ttl


### PR DESCRIPTION
This commit adds support for reading system security properties in a diagnostics dump and now dumps the positive and negative DNS cache settings from the system security policy.