### PR TITLE
Bring GC logs by default

### DIFF
--- a/src/main/java/com/elastic/support/diagnostics/commands/LogAndConfigCmd.java
+++ b/src/main/java/com/elastic/support/diagnostics/commands/LogAndConfigCmd.java
@@ -7,15 +7,19 @@ import com.elastic.support.util.SystemUtils;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.comparator.LastModifiedFileComparator;
+import org.apache.commons.io.filefilter.IOFileFilter;
 import org.apache.commons.io.filefilter.RegexFileFilter;
+import org.apache.commons.io.filefilter.TrueFileFilter;
 import org.apache.commons.io.filefilter.WildcardFileFilter;
 
 import java.io.File;
 import java.io.FileFilter;
+import java.io.FilenameFilter;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 
@@ -99,6 +103,10 @@ public class LogAndConfigCmd extends AbstractDiagnosticCmd {
                FileUtils.copyFileToDirectory(new File(logs + SystemProperties.fileSeparator + clusterName + ".log"), logDest);
                FileUtils.copyFileToDirectory(new File(logs + SystemProperties.fileSeparator + clusterName + "_index_indexing_slowlog.log"), logDest);
                FileUtils.copyFileToDirectory(new File(logs + SystemProperties.fileSeparator + clusterName + "_index_search_slowlog.log"), logDest);
+               final Collection<File> gcLogs = FileUtils.listFiles(new File(logs), new WildcardFileFilter("gc*.log*"), TrueFileFilter.INSTANCE);
+               for (final File gcLog : gcLogs) {
+                  FileUtils.copyFileToDirectory(gcLog, logDest);
+               }
 
                if (getAccess) {
                   FileUtils.copyFileToDirectory(new File(logs + SystemProperties.fileSeparator + clusterName + "_access.log"), logDest);


### PR DESCRIPTION
Assuming that the GC logs are available in the log directory (as they will be by default starting in 6.2.0), this commit brings all available GC logs back in the diagnostics bundles. Future refinements can handle cases when the GC logs are in another location.

Relates elastic/elasticsearch#27610